### PR TITLE
Add step-by-step Jupyter notebook for stock prediction

### DIFF
--- a/stock_price_prediction.ipynb
+++ b/stock_price_prediction.ipynb
@@ -1,0 +1,418 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b8f70277",
+   "metadata": {},
+   "source": [
+    "# **Imports and Parameters**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d594f68e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import yfinance as yf\n",
+    "from sklearn.preprocessing import MinMaxScaler\n",
+    "from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score\n",
+    "from tensorflow.keras.models import Sequential\n",
+    "from tensorflow.keras.layers import (\n",
+    "    LSTM,\n",
+    "    Dropout,\n",
+    "    Dense,\n",
+    "    BatchNormalization,\n",
+    ")\n",
+    "from tensorflow.keras import Input, Model\n",
+    "from tensorflow.keras.callbacks import EarlyStopping\n",
+    "import tensorflow as tf\n",
+    "\n",
+    "# =============================\n",
+    "# USER-CONFIGURABLE PARAMETERS\n",
+    "# =============================\n",
+    "TICKER = \"PLTR\"\n",
+    "LOOKBACK = 60             # sequence length in days\n",
+    "FORECAST_HORIZON = 90     # days to forecast\n",
+    "BATCH_SIZE = 32\n",
+    "EPOCHS = 100\n",
+    "DROPOUT_RATE = 0.2\n",
+    "VALIDATION_SPLIT = 0.2\n",
+    "EARLY_STOP_PATIENCE = 10\n",
+    "\n",
+    "# Set random seeds for reproducibility\n",
+    "np.random.seed(42)\n",
+    "tf.random.set_seed(42)\n",
+    "\n",
+    "print(\"Imports and parameters set.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c94d53d",
+   "metadata": {},
+   "source": [
+    "# **Feature Engineering**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c14e7e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = yf.download(TICKER, period=\"5y\")\n",
+    "df.to_csv(f\"{TICKER}_historical_data.csv\")\n",
+    "print(f\"Saved historical data to {TICKER}_historical_data.csv\")\n",
+    "\n",
+    "# Keep only relevant columns\n",
+    "features = df[[\"Open\", \"High\", \"Low\", \"Close\", \"Volume\"]].copy()\n",
+    "\n",
+    "# Technical indicators\n",
+    "features[\"MA7\"] = features[\"Close\"].rolling(window=7).mean()\n",
+    "features[\"MA21\"] = features[\"Close\"].rolling(window=21).mean()\n",
+    "delta = features[\"Close\"].diff()\n",
+    "up = delta.clip(lower=0)\n",
+    "down = -delta.clip(upper=0)\n",
+    "features[\"RSI\"] = 100 - (100/(1 + up.rolling(14).mean()/down.rolling(14).mean()))\n",
+    "\n",
+    "# Drop rows with NaNs after indicator calculation\n",
+    "features.dropna(inplace=True)\n",
+    "\n",
+    "print(\"Data downloaded and features engineered.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea8bd2d6",
+   "metadata": {},
+   "source": [
+    "# **Data Visualization**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d11c8890",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(14, 5))\n",
+    "plt.plot(features.index, features[\"Close\"], label=\"Close Price\")\n",
+    "plt.title(f\"Historical Closing Prices for {TICKER}\")\n",
+    "plt.xlabel(\"Date\")\n",
+    "plt.ylabel(\"Close Price USD ($)\")\n",
+    "plt.legend()\n",
+    "plt.show()\n",
+    "\n",
+    "print(\"Displayed historical closing prices.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "572bb944",
+   "metadata": {},
+   "source": [
+    "# **Data Preprocessing**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1abeef42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Determine training data length\n",
+    "training_data_len = int(np.ceil(len(features) * 0.8))\n",
+    "\n",
+    "# Split the data into training and testing datasets\n",
+    "train_features = features.iloc[:training_data_len]\n",
+    "test_features = features.iloc[training_data_len - LOOKBACK:]\n",
+    "\n",
+    "# Fit the scaler on the entire dataset to avoid distribution shift issues\n",
+    "feature_scaler = MinMaxScaler()\n",
+    "feature_scaler.fit(features)\n",
+    "train_scaled = feature_scaler.transform(train_features)\n",
+    "test_scaled = feature_scaler.transform(test_features)\n",
+    "\n",
+    "# Separate scaler for the 'Close' price for inverse transformation\n",
+    "price_scaler = MinMaxScaler()\n",
+    "price_scaler.fit(train_features[[\"Close\"]])\n",
+    "\n",
+    "# Function to create sequences of data\n",
+    "def create_dataset(dataset, lookback, target_index):\n",
+    "    X, y = [], []\n",
+    "    for i in range(lookback, len(dataset)):\n",
+    "        X.append(dataset[i - lookback : i])\n",
+    "        y.append(dataset[i, target_index])\n",
+    "    return np.array(X), np.array(y)\n",
+    "\n",
+    "# Generate sequences for training and testing\n",
+    "close_idx = features.columns.get_loc(\"Close\")\n",
+    "X_train, y_train = create_dataset(train_scaled, LOOKBACK, close_idx)\n",
+    "X_test, y_test = create_dataset(test_scaled, LOOKBACK, close_idx)\n",
+    "\n",
+    "# Number of features for model input\n",
+    "num_features = X_train.shape[2]\n",
+    "\n",
+    "print(\"Data preprocessed.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3680b8de",
+   "metadata": {},
+   "source": [
+    "# **Sequence Generation**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "951bd4ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_sequences(data, lookback, horizon):\n",
+    "    X, y_dir, y_forecast = [], [], []\n",
+    "    close_idx = list(features.columns).index(\"Close\")\n",
+    "    for i in range(lookback, len(data) - horizon):\n",
+    "        X.append(data[i - lookback:i])\n",
+    "        # Direction label: 1 if next day's close > today's close, else 0\n",
+    "        direction = 1 if data[i, close_idx] < data[i + 1, close_idx] else 0\n",
+    "        y_dir.append([direction])\n",
+    "        # Next 'horizon' days of normalized close prices\n",
+    "        y_forecast.append(data[i + 1 : i + 1 + horizon, close_idx])\n",
+    "    return (\n",
+    "        np.array(X),\n",
+    "        np.array(y_dir),\n",
+    "        np.array(y_forecast),\n",
+    "    )\n",
+    "\n",
+    "# Create all sequences from the full normalized feature set\n",
+    "all_scaled = feature_scaler.transform(features)\n",
+    "X_all, y_dir_all, y_forecast_all = create_sequences(all_scaled, LOOKBACK, FORECAST_HORIZON)\n",
+    "\n",
+    "# Split into train/val sets (80/20 split, matching earlier logic)\n",
+    "split_idx = int(len(X_all) * 0.8)\n",
+    "x_train, x_val = X_all[:split_idx], X_all[split_idx:]\n",
+    "y_dir_train, y_dir_val = y_dir_all[:split_idx], y_dir_all[split_idx:]\n",
+    "y_forecast_train, y_forecast_val = y_forecast_all[:split_idx], y_forecast_all[split_idx:]\n",
+    "\n",
+    "print(\"Sequences created.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ae7d959",
+   "metadata": {},
+   "source": [
+    "# **Build the LSTM Model**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "edf6fd62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inp = Input(shape=(LOOKBACK, num_features))\n",
+    "x = LSTM(64, return_sequences=True)(inp)\n",
+    "x = BatchNormalization()(x)\n",
+    "x = Dropout(DROPOUT_RATE)(x)\n",
+    "x = LSTM(32, return_sequences=False)(x)\n",
+    "x = BatchNormalization()(x)\n",
+    "x = Dropout(DROPOUT_RATE)(x)\n",
+    "\n",
+    "# Classification head: next-day direction (up/down)\n",
+    "dir_out = Dense(1, activation='sigmoid', name='direction')(x)\n",
+    "\n",
+    "# Regression head: 90-day forecast\n",
+    "reg_out = Dense(FORECAST_HORIZON, activation='linear', name='forecast')(x)\n",
+    "\n",
+    "model = Model(inputs=inp, outputs=[dir_out, reg_out])\n",
+    "\n",
+    "# Compile the model with appropriate losses and metrics for each output\n",
+    "model.compile(\n",
+    "    optimizer='adam',\n",
+    "    loss={'direction': 'binary_crossentropy', 'forecast': 'mse'},\n",
+    "    metrics={'direction': 'accuracy', 'forecast': 'mae'}\n",
+    ")\n",
+    "model.summary()\n",
+    "\n",
+    "print(\"Model built.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af9b42cc",
+   "metadata": {},
+   "source": [
+    "# **Train the Model**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27ebe60a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "early_stop = EarlyStopping(monitor=\"val_loss\", patience=EARLY_STOP_PATIENCE, restore_best_weights=True)\n",
+    "\n",
+    "history = model.fit(\n",
+    "    x_train,\n",
+    "    {'direction': y_dir_train, 'forecast': y_forecast_train},\n",
+    "    batch_size=BATCH_SIZE,\n",
+    "    epochs=EPOCHS,\n",
+    "    validation_data=(x_val, {'direction': y_dir_val, 'forecast': y_forecast_val}),\n",
+    "    callbacks=[early_stop],\n",
+    "    verbose=1,\n",
+    ")\n",
+    "\n",
+    "# Plot training and validation loss\n",
+    "plt.figure(figsize=(10, 4))\n",
+    "plt.plot(history.history['loss'], label='Training Loss')\n",
+    "plt.plot(history.history['val_loss'], label='Validation Loss')\n",
+    "plt.title('Training and Validation Loss')\n",
+    "plt.xlabel('Epoch')\n",
+    "plt.ylabel('Loss')\n",
+    "plt.legend()\n",
+    "plt.show()\n",
+    "\n",
+    "# Plot total and per-output loss/metrics\n",
+    "plt.figure(figsize=(10, 4))\n",
+    "plt.plot(history.history['loss'], label='Total Training Loss')\n",
+    "plt.plot(history.history['val_loss'], label='Total Validation Loss')\n",
+    "if 'direction_loss' in history.history:\n",
+    "    plt.plot(history.history['direction_loss'], label='Direction Loss (Train)')\n",
+    "    plt.plot(history.history['val_direction_loss'], label='Direction Loss (Val)')\n",
+    "if 'forecast_loss' in history.history:\n",
+    "    plt.plot(history.history['forecast_loss'], label='Forecast Loss (Train)')\n",
+    "    plt.plot(history.history['val_forecast_loss'], label='Forecast Loss (Val)')\n",
+    "plt.title('Model Loss During Training')\n",
+    "plt.xlabel('Epoch')\n",
+    "plt.ylabel('Loss')\n",
+    "plt.legend()\n",
+    "plt.show()\n",
+    "\n",
+    "print(\"Model trained.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff11c207",
+   "metadata": {},
+   "source": [
+    "# **Make Predictions**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3ecdc79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dir_pred, forecast_pred = model.predict(x_val)\n",
+    "\n",
+    "# Inverse transform the forecast predictions and actuals for visualization\n",
+    "forecast_pred_inv = price_scaler.inverse_transform(forecast_pred)\n",
+    "y_forecast_val_inv = price_scaler.inverse_transform(y_forecast_val)\n",
+    "\n",
+    "print(\"Predictions generated.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10bd56c0",
+   "metadata": {},
+   "source": [
+    "# **Evaluate Model Performance**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5594720c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.metrics import accuracy_score\n",
+    "\n",
+    "# Direction classification metrics\n",
+    "dir_pred_bin = (dir_pred > 0.5).astype(int)\n",
+    "dir_acc = accuracy_score(y_dir_val, dir_pred_bin)\n",
+    "print(f\"Direction Accuracy: {dir_acc:.3f}\")\n",
+    "\n",
+    "# Forecast regression metrics (per horizon step, or average)\n",
+    "rmse = np.sqrt(mean_squared_error(y_forecast_val_inv, forecast_pred_inv))\n",
+    "mae = mean_absolute_error(y_forecast_val_inv, forecast_pred_inv)\n",
+    "r2 = r2_score(y_forecast_val_inv, forecast_pred_inv)\n",
+    "print(f\"Forecast RMSE: {rmse:.2f}\")\n",
+    "print(f\"Forecast MAE: {mae:.2f}\")\n",
+    "print(f\"Forecast R²: {r2:.2f}\")\n",
+    "\n",
+    "print(\"Evaluation complete.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bb20cd9",
+   "metadata": {},
+   "source": [
+    "# **Visualize Forecast**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "caa3b700",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(14, 5))\n",
+    "for i in range(min(5, len(forecast_pred_inv))):\n",
+    "    plt.plot(range(FORECAST_HORIZON), y_forecast_val_inv[i], color='blue', alpha=0.3, label='Actual' if i==0 else \"\")\n",
+    "    plt.plot(range(FORECAST_HORIZON), forecast_pred_inv[i], color='red', alpha=0.3, label='Predicted' if i==0 else \"\")\n",
+    "plt.title(f\"{TICKER} {FORECAST_HORIZON}-Day Forecast (Validation Examples)\")\n",
+    "plt.xlabel(\"Forecast Day\")\n",
+    "plt.ylabel(\"Close Price USD ($)\")\n",
+    "plt.legend()\n",
+    "plt.show()\n",
+    "\n",
+    "print(\"Forecast visualization displayed.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d39eb9be",
+   "metadata": {},
+   "source": [
+    "# **Save the Model**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bcc16d1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.save('stock_price_model.keras')\n",
+    "\n",
+    "print(\"Model saved to stock_price_model.keras.\")\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Jupyter notebook that breaks the stock price prediction workflow into sequential cells with descriptive headers.
- each cell ends with a print statement for quick feedback when executed individually.

## Testing
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_6894ed2c866c83328a9aa61c6a0ea7ba